### PR TITLE
Why only expose C#-style API from an F# lib if you can expose both?

### DIFF
--- a/BitBankApi/PrivateApi.fs
+++ b/BitBankApi/PrivateApi.fs
@@ -336,13 +336,16 @@ type PrivateApi(apiKey: string, apiSecret: string, [<Optional; DefaultParameterV
                               [<Optional>] ?endDate: int) =
     this.GetTradeHistoryAsyncPrivate(pair, count, orderId, since, endDate).GetAwaiter().GetResult()
 
-  member this.GetWithdrawalAccountAsync(asset: string) =
+  member this.AsyncGetWithdrawalAccount(asset: string) =
     let arg = Some [("asset", asset :> obj)]
-    (async {
+    async {
       let! resp = get "/user/withdrawal_account" arg
       failIfError resp |> ignore
       return JsonSerializer.Deserialize<Response<WithdrawalAccountRecord>>(resp, StandardResolver.CamelCase)
-    } |> Async.StartAsTask).ConfigureAwait(false)
+    }
+
+  member this.GetWithdrawalAccountAsync(asset: string) =
+    (this.AsyncGetWithdrawalAccount asset |> Async.StartAsTask).ConfigureAwait(false)
 
   member this.GetWithdrawalAccount(asset: string) =
     this.GetWithdrawalAccountAsync(asset).GetAwaiter().GetResult()

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ using BitBankApi
   }
 ```
 
-async methods are postfixed with `Async` , and returns `Task<T>` (instead of F#'s `Async<T>`).
+Asynchronous methods are:
+* postfixed with `Async` and return `Task<T>` (for C# consumers)
+* prefixed with `Async` and return `Async<'T>` (for F# consumers)
 
 Be careful when you use async methods that the order of executions is fixed.
 


### PR DESCRIPTION
Exposing Async<'T> APIs is friendly to F# consumers, and this is
a logical thing to do especially if the library is implemented in
F# language :)

(If you like what you see, let me know, and I will finish this PR for all the methods instead of just one.)